### PR TITLE
ct: Refactor out generic helpers / enhance tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@
  *
  */
 
-var extend = require("./lib/extend");
+var extend = require("./lib/extend"),
+    omit = require("./lib/omit");
 
 module.exports = function () {
 	return new NanoDocUpdater();
@@ -89,17 +90,6 @@ function useNewVersion(existing, newVer) {
 	return newVer;
 }
 
-
-function omit(source, blacklist) {
-	var result = {};
-
-	Object.getOwnPropertyNames(source).forEach(function (e) {
-		if (blacklist.indexOf(e) === -1)
-			result[e] = source[e];
-	});
-
-	return result;
-}
 
 /* Create-or-update a document: First fetch the existing revision, then
    insert a new one.  Optional f_ShouldUpdate and f_Merge functions

--- a/lib/omit.js
+++ b/lib/omit.js
@@ -1,0 +1,12 @@
+module.exports = function omit(source/*, blacklist1, blacklist2, blacklist3 */) {
+    var result = {};
+
+    var blacklist = Array.prototype.slice.call(arguments, 1);
+    
+    Object.getOwnPropertyNames(source).forEach(function (e) {
+        if (blacklist.indexOf(e) === -1)
+            result[e] = source[e];
+    });
+
+    return result;
+};

--- a/test/unit/test-omit.js
+++ b/test/unit/test-omit.js
@@ -1,0 +1,39 @@
+var test = require("tape-catch"),
+    omit = require("../../lib/omit");
+
+test("omitting a field from an object with no fields...", function (t) {
+    var o1 = {};
+    var result = omit(o1, "foo");
+    t.notEqual(result, o1, "...results in a different object");
+    t.end();
+});
+
+test("omitting a field from an object with no fields...", function (t) {
+    var o1 = {};
+    var result = omit(o1, "foo");
+    t.deepEqual(result, o1, "...results in an equivalent object");
+    t.end();
+});
+
+test("omitting a field from an object with only that field...", function (t) {
+    var o1 = { foo: 1 };
+    var result = omit(o1, "foo");
+    t.deepEqual(result, {}, "...results in an empty object");
+    t.end();
+});
+
+test("omitting a field from an object with several fields, including the provided field...", function (t) {
+    var o1 = { foo: 1, bar: 2 };
+    var result = omit(o1, "foo");
+    var expected = { bar: 2 };
+    t.deepEqual(result, expected, "...results in an object with that field removed");
+    t.end();
+});
+
+test("omitting a field from an object with several fields, but not including that field...", function (t) {
+    var o1 = { foo: 1, bar: 2 };
+    var result = omit(o1, "baz");
+    t.deepEqual(result, o1, "...results in an equivalent object");
+    t.end();
+});
+


### PR DESCRIPTION
- Just like `extend()`, `omit()` is pretty generic, and should be unit
  tested.