### PR TITLE
Deconstruct the sample code from the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ async.series([
         version: 1
     })
     .shouldUpdate((existing, newDoc) => {
-        return !existing.version || existing.version < newVer.version;
+        return !existing.version || existing.version < newDoc.version;
     })
     .updateJob(),
     

--- a/README.md
+++ b/README.md
@@ -87,114 +87,131 @@ Returns a function that can be used to perform an update at a later time.  This 
 
 ## Examples
 
+Loading the module and binding it to to a database handle:
+
 ```
 var updater = require("nano-doc-updater");
 var db = require("nano")("https://mydatabase.com").use("mydatabase");
+updater.db(db);
+...
+...
+```
 
-/* Update a design document */
+Updating a design document:
+
+```
+var designDocument = {
+    language: "javascript",
+    version: 1
+};
+
 updater
-.db(db)
-.existingDoc(null) // If you happened to already fetch the current revision, provide it here.  Otherwise it will be fetched first.
-.newDoc({
-	language: "javascript",
-	version: 1
-})
+.newDoc(designDocument)
 .id("_design/foo")
 .shouldUpdate(function (existing, newVer) {
-	/* For a versioned design document, there are some times where
-	   in the face of an existing document, we don't want to update. 
-	   Namely, when the published version is at or above the level
-	   we were about to publish. */
+	/* Only publish a new document when it's below the version
+	   required by this app */
 	return !existing.version || existing.version < newVer.version;
 })
-.merge(function (existing, newVer) {
-	return newVer; 
-	// to ensure this process eventually terminates, 
-	// nano-doc-updater will bump the _rev for us.
+.merge(function (existing, newDoc) {
+	return newDoc; 
+	/* To ensure this process will eventually terminate, 
+	   nano-doc-updater will copy `_rev` from the 
+       existing document to the newDoc one, just before
+       publishing it to CouchDB. */
 })
 .update(function (err) {
-	if (err)
-		process.exit(1);
-
-	/* Reuse the same updater to perform another design update. */
-	updater
-	.newDoc({
-		language: "javascript",
-		version: 2,
-		_views: {
-			count: {
-				map: function (d) {
-					emit(null, 1);
-				},
-				reduce: function (k, v, r) {
-					sum(v);
-				}
-			}
-		}
-	})
-	.update(function (err) {
-		/* Reuse the same updater to update some other unrelated doc with that design above. */
-		updater
-		.id("foo")
-		.shouldUpdate(null) // the default: always try to update
-		.merge(null) 	    // the default: overwrite the existing document
-		.update(function (err) {
-			if (err)
-				process.exit(1);
-
-			/* Delete that document. */
-			updater
-			.shouldCreate(false)
-			.merge(function (published) {
-				var r = {};
-				Object.getOwnPropertyNames(published).forEach(function (p) {
-					r[p] = published[p];
-				});
-				return r;
-			})
-			.update(function (err) {
-				if (err)
-					process.exit(1);
-
-				console.log("All done!");
-			});
-		})
-	});
+    // handle errors
 });
+```
 
-/* Or use Async for flow control and avoid all those indents. */
+Performing another update with the same updater:
+
+```
+var newerDesignDocument = {
+    language: "javascript",
+    version: 2,
+    views: {
+        count: {
+            map: function (d) {
+                emit(null, 1);
+            },
+            reduce: function (k, v, r) {
+                sum(v);
+            }
+        }
+    }
+};
+
+/*
+ * shouldUpdate() is unchanged, so updates will still only
+ * occur if the published version is below 2.
+ */
+updater
+.newDoc(newerDesignDocument)
+.update((err) => {
+    // handle errors
+})
+;
+```
+
+Publish that design document to another document, `foo`:
+
+```
+updater
+.id("foo")
+.shouldUpdate(null) // always update
+.merge(null) // overwrite
+.update((err) => {
+    // handle errors
+});
+```
+
+Delete that new document:
+
+```
+updater
+.merge((existing) => {
+    existing._deleted = true;
+    return existing;
+})
+.update((err) => {
+    // handle errors
+});
+```
+
+Delete that design document from way back:
+
+```
+updater.id("_design/foo").update((err) => {
+    // handle errors
+});
+```
+
+Use `async` to sequence the flow above:
+
+```
 var async = require("async");
 
 async.series([
-	/* JOB1: Update or create a design document. */
-	updater
-	.db(db)
-	.existingDoc(null)
-	.newDoc({
-		language: "javascript",
-		version: 1
-	})
-	.id("_design/foo")
-	.shouldUpdate(function (existing, newVer) {
-		return !existing.version || existing.version < newVer.version;
-	})
-	.merge(function (existing, newVer) {
-		var clone = {};
-		Object.getOwnProperyNames(newVer).forEach(function (p) {
-			clone[p] = newVer[p];
-		});
-		clone._rev = existing._rev;
-
-		# This is actually the default behavior :-)
-	})
-	.updateJob(),
-
-	/* JOB2: Update the same design document again. */
-	updater
-	.newDoc({
+    // Add a design document.  Only publish this if the in-db version is
+    // lower.
+    updater.db(db).id("_design/foo").newDoc({
+        language: "javascript",
+        version: 1
+    })
+    .shouldUpdate((existing, newDoc) => {
+        return !existing.version || existing.version < newVer.version;
+    })
+    .updateJob(),
+    
+    
+    // Update the design document with an even newer version,
+    // but, again, only if it's out of date.
+    updater.db(db).id("_design/foo").newDoc({
 		language: "javascript",
 		version: 2,
-		_views: {
+		views: {
 			count: {
 				map: function (d) {
 					emit(null, 1);
@@ -204,33 +221,30 @@ async.series([
 				}
 			}
 		}
-	})
-	.updateJob(),
-
-	/* JOB3: Update or create some other document in the same db. */
-	updater
-	.id("foo")
-	.shouldUpdate(null) // use default: always replace existing doc.
-	.merge(null) // use default: no fancy merge.  just bump the _rev and insert.
-	.updateJob(),
-
-	/* JOB4: Delete the document we just created. */
-	updater
-	.shouldCreate(false)
-	.merge(function (published) {
-		var r = {};
-		Object.getOwnPropertyNames(published).forEach(function (p) {
-			r[p] = published[p];
-		});
-
-		r._deleted = true;
-		return r;
-	}).updateJob()
-
-	// The DB will behave as though the document doesn't exist, so recreating
-	// would be a matter of running JOB3 again.
-], function (err, r) {
-	console.log("All done");
+    })
+    .updateJob(),
+    
+    
+    // Place that same document somewhere else in the db:
+    updater.shouldUpdate(null).merge(null).id("foo").updateJob(),
+    
+    // Delete that document:
+    updater
+    .merge((existing) => {
+      existing._deleted = true;
+      return existing;
+    })
+    .updateJob(),
+    
+    // Delete the design document:
+    updater
+    .id("_design/foo")
+    .updateJob()
+], (err) => {
+    if (err) {
+        // handle errors in any of the above.
+    }
+    console.log("All done");
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "index.js",
   "homepage": "https://github.com/IBM/node-nano-doc-updater/releases",
   "devDependencies": {
+    "async": "^2.1.2",
     "eslint": "^3.7.1",
     "nano": "^6.2.0",
     "tap-spec": "^4.1.1",

--- a/test/system/test-readme-async-flow.js
+++ b/test/system/test-readme-async-flow.js
@@ -1,0 +1,108 @@
+var test = require("tape-catch"),
+    Promise = require("bluebird"),
+    nanoDocUpdater = require("../../"),
+    resetTestDb = require("./lib/reset-test-db"),
+    async = require("async");
+
+test("after running through the 'async' flow from the README...", (t) => {
+    var db = null;
+    var docId = "a";
+    var doc = { a: 1 };
+    var designDocId = "_design/foo";
+    var arbitraryDocId = "foo";
+
+    resetTestDb()
+    .then((rawDb) => {
+        db = Promise.promisifyAll(rawDb);
+
+        var updater = nanoDocUpdater()
+        .db(rawDb);
+
+        return Promise.promisify(readmeAsyncFlow)(rawDb, updater, designDocId, arbitraryDocId);
+    })
+    .then(() => {
+        t.pass("...it at least succeeded");
+
+        return Promise.promisify(db.getAsync)(designDocId)
+        .then(() => {
+            t.fail("...the design doc inserted in the sample code still exists (i.e. was not deleted)");
+        })
+        .catch(NotFoundError, () => {
+            t.pass("...the design doc inserted in the sample code was removed (as expected)");
+        });
+    })
+    .then(() => {
+        return Promise.promisify(db.getAsync)(arbitraryDocId)
+        .then(() => {
+            t.fail("...the arbitrary doc inserted in the sample code still exists (i.e. was not deleted)");
+        })
+        .catch(NotFoundError, () => {
+            t.pass("...the arbitrary doc inserted in the sample code was removed (as expected)");
+        });
+    })
+    .catch((e) => {
+        if (e instanceof Error) {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        } else {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        }
+
+        throw(e);
+    })
+    .finally(() => {
+        t.end();
+    });
+});
+
+function readmeAsyncFlow(db, updater, designDocId, arbitraryDocId, callback) {
+    async.series([
+        // Add a design document.  Only publish this if the in-db version is
+        // lower.
+        updater.db(db).id(designDocId).newDoc({
+            language: "javascript",
+            version: 1
+        })
+        .shouldUpdate((existing, newDoc) => {
+            return !existing.version || existing.version < newDoc.version;
+        })
+        .updateJob(),
+
+
+        // Update the design document with an even newer version,
+        // but, again, only if it's out of date.
+        updater.db(db).id(designDocId).newDoc({
+            language: "javascript",
+            version: 2,
+            views: {
+                count: {
+                    map: "function (d) { emit(null, 1); }",
+                    reduce: "function (k, v, r) { sum(v); }"
+                }
+            }
+        })
+        .updateJob(),
+
+
+        // Place that same document somewhere else in the db:
+        updater.shouldUpdate(null).merge(null).id(arbitraryDocId).updateJob(),
+
+        // Delete that document:
+        updater
+        .merge((existing) => {
+            existing._deleted = true;
+            return existing;
+        })
+        .updateJob(),
+
+        // Delete the design document:
+        updater
+        .id(designDocId)
+        .updateJob()
+    ], callback);
+}
+
+function NotFoundError(e) {
+    return e && e.error === "not_found";
+}

--- a/test/system/test-readme-async-flow.js
+++ b/test/system/test-readme-async-flow.js
@@ -6,8 +6,6 @@ var test = require("tape-catch"),
 
 test("after running through the 'async' flow from the README...", (t) => {
     var db = null;
-    var docId = "a";
-    var doc = { a: 1 };
     var designDocId = "_design/foo";
     var arbitraryDocId = "foo";
 

--- a/test/system/test-readme-example-flows.js
+++ b/test/system/test-readme-example-flows.js
@@ -1,0 +1,165 @@
+var test = require("tape-catch"),
+    Promise = require("bluebird"),
+    resetTestDb = require("./lib/reset-test-db"),
+    nanoDocUpdater = require("../../");
+
+test("while testing the scenario from the README...", (t) => {
+    var db = null;
+    var designDocId = "_design/foo",
+        otherDocId = "foo",
+        designDoc1 = { language: "javascript", version: 1 };
+
+    /* eslint-disable */
+    var designDoc2 = {
+        language: "javascript",
+        version: 2,
+        views: {
+            count: {
+                map: 'function (d) { emit(null, 1); }',
+                reduce: 'function (k, v, r) { sum(v); }'
+            }
+        }
+    }; /* eslint-enable */
+
+    var updater = null;
+
+    resetTestDb()
+    .then((rawDb) => {
+        db = Promise.promisifyAll(rawDb);
+        updater = nanoDocUpdater();
+
+        t.comment("...after inserting a design document...");
+
+        return Promise.promisify(
+            updater
+            .db(db)
+            .newDoc(designDoc1)
+            .id(designDocId)
+            .shouldUpdate((existing, newDoc) => {
+                return !existing.version || existing.version < newDoc.version;
+            })
+            .merge(function (existing, newDoc) {
+                return newDoc;
+            })
+            .update,
+            updater
+        )();
+    })
+    .then(() => {
+        return db.getAsync(designDocId);
+    })
+    .then((r) => {
+        var doc = r[0];
+
+        delete doc._id;
+        delete doc._rev;
+
+        t.deepEqual(doc, designDoc1, "...does it equal what was inserted?");
+    })
+    .then(() => {
+        t.comment("...after updating it to a newer version (using the same update logic)...");
+
+        return Promise.promisify(
+            updater
+            .newDoc(designDoc2)
+            .update,
+            updater
+        )();
+    })
+    .then(() => {
+        return db.getAsync(designDocId);
+    })
+    .then((r) => {
+        var doc = r[0];
+
+        delete doc._id;
+        delete doc._rev;
+
+        t.deepEqual(doc, designDoc2, "...is it actually equivalent to the updated version, as we inserted it?");
+    })
+    .then(() => {
+        t.comment("...after inserting that design document to an arbitrary, different, _id...");
+
+        return Promise.promisify(
+            updater
+            .id(otherDocId)
+            .shouldUpdate(null)
+            .merge(null)
+            .update,
+            updater
+        )();
+    })
+    .then(() => {
+        return db.getAsync(otherDocId);
+    })
+    .then((r) => {
+        var doc = r[0];
+
+        delete doc._id;
+        delete doc._rev;
+
+        t.deepEqual(doc, designDoc2, "...does that same document exist at this arbitrary, different, _id?");
+    })
+    .then(() => {
+        t.comment("...after removing this new document...");
+        return Promise.promisify(
+            updater
+            .merge((existing) => {
+                existing._deleted = true;
+                return existing;
+            })
+            .update,
+            updater
+        )();
+    })
+    .then(() => {
+        return db.getAsync(otherDocId)
+        .then(() => {
+            t.fail("...a request to fetch the document succeeds.  It should have failed!");
+        })
+        .catch(NotFoundError, () => {
+            t.pass("...a request to fetch the document fails.  This is expected.");
+        });
+    })
+    .then(() => {
+        t.comment("...after removing the original design document...");
+
+        return Promise.promisify(
+            updater
+            .id(designDocId)
+            .merge((existing) => {
+                existing._deleted = true;
+                return existing;
+            })
+            .update,
+            updater
+        )();
+    })
+    .then(() => {
+        return db.getAsync(designDocId)
+        .then(() => {
+            t.fail("...a request to fetch the document succeeds.  It should have failed!");
+        })
+        .catch(NotFoundError, () => {
+            t.pass("...a request to fetch the document fails.  This is expected.");
+        });
+    })
+    .catch((e) => {
+        if (e instanceof Error) {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        } else {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        }
+
+        throw(e);
+    })
+    .finally(() => {
+        t.end();
+    });
+});
+
+function NotFoundError(e) {
+    return e && e.error === "not_found";
+}

--- a/test/system/test-readme-synopsis-flow.js
+++ b/test/system/test-readme-synopsis-flow.js
@@ -1,0 +1,59 @@
+var test = require("tape-catch"),
+    Promise = require("bluebird"),
+    resetTestDb = require("./lib/reset-test-db");
+
+test("after execiting the steps in the Synopsis section" + 
+     "the README (insert a design document with custom)" +
+     "update criteria...", (t) => {
+    var db = null;
+    var designDocId = "_design/foo";
+    var designDoc = { language: "javascript", version: 1 };
+
+    resetTestDb()
+    .then((rawDb) => {
+        db = Promise.promisifyAll(rawDb);
+        return Promise.promisify(synopsisFlow)(db, designDocId, designDoc);
+    })
+    .then(() => {
+        return db.getAsync(designDocId);
+    })
+    .then((r) => {
+        var doc = r[0];
+        delete doc._id;
+        delete doc._rev;
+
+        t.deepEquals(doc, designDoc, "...and after fetching the design document manually, does it match what we inserted?");
+    })
+    .catch((e) => {
+        if (e instanceof Error) {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        } else {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        }
+
+        throw(e);
+    })
+    .finally(() => {
+        t.end();
+    });
+});
+
+function synopsisFlow(db, designDocId, designDoc, callback) {
+    var nanoDocUpdater = require("../../");
+    var updater = nanoDocUpdater(db);
+
+    updater
+    .db(db)
+    .existingDoc(null)
+    .newDoc(designDoc)
+    .id(designDocId)
+    .shouldUpdate((existing, newDoc) => {
+        return !existing.version || existing.version < newDoc.version;
+    })
+    .merge((existing, newDoc) => {
+        return newDoc;
+    })
+    .update(callback);
+}


### PR DESCRIPTION
- Break up the examples in the README so they're easier to follow.
- Add tests to verify the examples in the README as part of CI.